### PR TITLE
Use the correct method for #alter_database_privilege test

### DIFF
--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -118,7 +118,7 @@ describe InfluxDB::Client do
 
   describe "#alter_database_privilege" do
     it "should POST to alter privileges for a user on a database" do
-      stub_request(:post, "http://influxdb.test:9999/db/foo/users/useruser").write(
+      stub_request(:post, "http://influxdb.test:9999/db/foo/users/useruser").with(
         :query => {:u => "username", :p => "password"}
       )
       


### PR DESCRIPTION
Whoops.

```
3) InfluxDB::Client#alter_database_privilege should POST to alter privileges for a user on a database
     Failure/Error: stub_request(:post, "http://influxdb.test:9999/db/foo/users/useruser").write(
     NoMethodError:
       undefined method `write' for #<WebMock::RequestStub:0x7f83f108b340>
```
