### PR TITLE
Use `db` to get the database list

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -57,7 +57,7 @@ module InfluxDB
     end
 
     def get_database_list
-      url = full_url("dbs")
+      url = full_url("db")
 
       response = @http.request(Net::HTTP::Get.new(url))
       JSON.parse(response.body)

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -54,7 +54,7 @@ describe InfluxDB::Client do
   describe "#get_database_list" do
     it "should GET a list of databases" do
       database_list = [{"name" => "foobar"}]
-      stub_request(:get, "http://influxdb.test:9999/dbs").with(
+      stub_request(:get, "http://influxdb.test:9999/db").with(
         :query => {:u => "username", :p => "password"}
       ).to_return(:body => JSON.generate(database_list), :status => 200)
 


### PR DESCRIPTION
The dbs endpoint is gone:

https://github.com/influxdb/influxdb/commit/e4d19b9
