### PR TITLE
return original value if json parsing fails

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -18,32 +18,19 @@ module InfluxDB
     end
 
     def load
-      if json?
+      if maybe_json?
         begin
           JSON.parse(value)
         rescue JSON::ParserError => e
-          raise InfluxDB::JSONParserError, e.message
+          value
         end
       else
         value
       end
     end
 
-    def json?
-      value =~ /(
-        # define subtypes and build up the json syntax, BNF-grammar-style
-        # The {0} is a hack to simply define them as named groups here but not match on them yet
-        # I added some atomic grouping to prevent catastrophic backtracking on invalid inputs
-        (?<number>  -?(?=[1-9]|0(?!\d))\d+(\.\d+)?([eE][+-]?\d+)?){0}
-        (?<boolean> true | false | null ){0}
-        (?<string>  " (?>[^"\\\\]* | \\\\ ["\\\\bfnrt\/] | \\\\ u [0-9a-f]{4} )* " ){0}
-        (?<array>   \[ (?> \g<json> (?: , \g<json> )* )? \s* \] ){0}
-        (?<pair>    \s* \g<string> \s* : \g<json> ){0}
-        (?<object>  \{ (?> \g<pair> (?: , \g<pair> )* )? \s* \} ){0}
-        (?<json>    \s* (?> \g<number> | \g<boolean> | \g<string> | \g<array> | \g<object> ) \s* ){0}
-        )
-      \A \g<json> \Z
-      /uix
+    def maybe_json?
+      value.is_a?(String) && value =~ /\A(\{|\[).*(\}|\])$/
     end
   end
 end

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -4,10 +4,24 @@ describe InfluxDB::PointValue do
 
   describe 'load' do
 
-    it 'should raise error if json parsing fails' do
-      val = InfluxDB::PointValue.new('{invalid_json')
-      val.should_receive(:json?).and_return(true)
-      expect { val.load }.to raise_error(InfluxDB::JSONParserError)
+    it 'should parse json as array' do
+      val = InfluxDB::PointValue.new('["foo", "bar"]')
+      val.load.should == %w(foo bar)
+    end
+
+    it 'should parse json as hash' do
+      val = InfluxDB::PointValue.new('{"foo":"bar"}')
+      val.load.should == {"foo" => "bar"}
+    end
+
+    it 'should return string value if invalid json array' do
+      val = InfluxDB::PointValue.new('[foo,bar]')
+      val.load.should == '[foo,bar]'
+    end
+
+    it 'should return string value if invalid json hash' do
+      val = InfluxDB::PointValue.new('{foo:"bar"}')
+      val.load.should == '{foo:"bar"}'
     end
   end
 end


### PR DESCRIPTION
I found another bug with the json regex. This approach is safer.
