### PR TITLE
Rename identical column names

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -192,6 +192,10 @@ module InfluxDB
 
     def denormalize_series series
       columns = series['columns']
+
+      h = Hash.new(-1)
+      columns = columns.map {|v| h[v] += 1; h[v] > 0 ? "#{v}~#{h[v]}" : v }
+
       series['points'].map do |point|
         decoded_point = point.map do |value|
           InfluxDB::PointValue.new(value).load

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -361,7 +361,7 @@ describe InfluxDB::Client do
 
   describe "#execute_queries" do
     before(:each) do
-      data = [{ :name => "foo", :columns => ["name", "age"], :points => [["shahid", 99],["dix", 50]]}]
+      data = [{ :name => "foo", :columns => ["name", "age", "count", "count"], :points => [["shahid", 99, 1, 2],["dix", 50, 3, 4]]}]
 
       stub_request(:get, "http://influxdb.test:9999/db/database/series").with(
         :query => { :q => "select * from foo", :u => "username", :p => "password"}
@@ -370,7 +370,7 @@ describe InfluxDB::Client do
       )
     end
 
-    expected_series = { 'foo' => [{"name" => "shahid", "age" => 99}, {"name" => "dix", "age" => 50}]}
+    expected_series = { 'foo' => [{"name" => "shahid", "age" => 99, "count" => 1, "count~1" => 2}, {"name" => "dix", "age" => 50, "count" => 3, "count~1" => 4}]}
 
     it 'can execute a query with a block' do
       series = { }


### PR DESCRIPTION
At present InfluxDB doesn't support column aliases. So, the following query:

```
select count(distinct(user_id)), count(user_id) from events
```

return dataset with the following column names: ["count", "count"]. It is cause problem because `denormalize_series` function convert dataset to hash with one `count` field.

To avoid this problem I have made a patch which rename identical columns.

Could you please verify this pull request and approve it?
