### PR TITLE
Make InfluxDB::Errors StandardErrors again

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -226,7 +226,11 @@ module InfluxDB
         http.read_timeout = @read_timeout
         http.use_ssl = @use_ssl
         block.call(http)
-      rescue StandardError => e
+
+      # we do want to catch anything from net/http in order to issue a retry.
+      # The NET_HTTP_EXCEPTIONS list is taken from
+      # https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http.rb
+      rescue *InfluxDB::NET_HTTP_EXCEPTIONS, Timeout::Error => e
         log :error, "Failed to contact host #{host}: #{e.inspect} - retrying in #{delay}s."
         log :info, "Queue size is #{@queue.length}." unless @queue.nil?
 

--- a/lib/influxdb/errors.rb
+++ b/lib/influxdb/errors.rb
@@ -1,5 +1,5 @@
 module InfluxDB
-  class Error < Exception
+  class Error < StandardError
   end
 
   class AuthenticationError < Error
@@ -10,4 +10,23 @@ module InfluxDB
 
   class JSONParserError < Error
   end
+
+  # Taken from
+  # https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http.rb
+  NET_HTTP_EXCEPTIONS = [
+    EOFError,
+    Errno::ECONNABORTED,
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::EHOSTUNREACH,
+    Errno::EINVAL,
+    Errno::ENETUNREACH,
+    Net::HTTPBadResponse,
+    Net::HTTPHeaderSyntaxError,
+    Net::ProtocolError,
+    SocketError,
+    Zlib::GzipFile::Error,
+  ]
+
+  NET_HTTP_EXCEPTIONS << OpenSSL::SSL::SSLError if defined?(OpenSSL)
 end


### PR DESCRIPTION
**WIP** expect rebasing!

As discussed in https://github.com/influxdb/influxdb-ruby/issues/40 inheriting custom exceptions from `Exception` is bad practice and poses some unexpected behavior to gem users.

I made `InfluxDB::Error` inherit from `StandardError` again.

`Client#connect_with_retry` now also only retries exceptions raised by `net/http` so that `Client#query` used with blocks can also benefit from being used with `Client#connect_with_retry`.
## TODOs
- [ ] add specs for `Client#connect_with_retry`'s retry logic
