### PR TITLE
Add "rake console" to start an IRB session with influxdb gem loaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,11 @@ RSpec.configure do |config|
 end
 
 task :default => :spec
+
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'influxdb'
+  ARGV.clear
+  IRB.start
+end


### PR DESCRIPTION
This is a must-have helper to work with gem development: `rake console` will fire up an IRB session and initialize the gem so you can get started to interactively poke around.
