### PR TITLE
better threadsafety in handling of the worker and a spec for async on clent

### DIFF
--- a/lib/influxdb/worker.rb
+++ b/lib/influxdb/worker.rb
@@ -27,6 +27,10 @@ module InfluxDB
       Thread.list.count {|t| t[:influxdb] == self.object_id}
     end
 
+    def push(payload)
+      queue.push(payload)
+    end
+
     def spawn_threads!
       NUM_WORKER_THREADS.times do |thread_num|
         log :debug, "Spawning background worker thread #{thread_num}."

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -381,6 +381,27 @@ describe InfluxDB::Client do
 
       @influxdb.write_point("seriez", data, false, "m").should be_a(Net::HTTPOK)
     end
+
+    describe "async" do
+
+      it "should push to the worker with payload if client is async" do
+        @influxdb = InfluxDB::Client.new "database", :host => "influxdb.test", :async => true
+
+        data = {:name => "juan", :age => 87, :time => Time.now.to_i}
+        @influxdb.stub_chain(:worker, :push).with(hash_including({:name => 'seriez'})).and_return(:ok)
+        @influxdb.write_point("seriez", data).should eq(:ok)
+      end
+
+      it "should push to the worker with payload if write_point call is async" do
+        @influxdb = InfluxDB::Client.new "database", :host => "influxdb.test", :async => false
+
+        data = {:name => "juan", :age => 87, :time => Time.now.to_i}
+        @influxdb.stub_chain(:worker, :push).with(hash_including({:name => 'seriez'})).and_return(:ok)
+        @influxdb.write_point("seriez", data, true).should eq(:ok)
+      end
+
+    end
+
   end
 
   describe "#execute_queries" do


### PR DESCRIPTION
Noticed that the async write_point wasn't actually threadsafe (worker assignment isn't threadsafe).  it was also untested.  This fixes that and adds an async test.

I'm probably going to have a full PRs based on the worker... ideally there should be no sleep in the worker.
