### PR TITLE
add a randomization to the sleep and an integration spec for worker.rb

### DIFF
--- a/lib/influxdb/worker.rb
+++ b/lib/influxdb/worker.rb
@@ -45,7 +45,7 @@ module InfluxDB
 
           while true
             self.check_background_queue(thread_num)
-            sleep SLEEP_INTERVAL
+            sleep rand(SLEEP_INTERVAL)
           end
         end
       end

--- a/spec/influxdb/worker_spec.rb
+++ b/spec/influxdb/worker_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require 'timeout'
+
+describe InfluxDB::Worker do
+  let(:fake_client) { double() }
+  let(:worker) { InfluxDB::Worker.new(fake_client) }
+
+  describe "#push" do
+    let(:payload) { {:name => "juan", :age => 87, :time => Time.now.to_i} }
+
+    it "should _write to the client" do
+      queue = Queue.new
+      expect(fake_client).to receive(:_write).once.with([payload]).and_return do |data|
+        queue.push(:received)
+      end
+      worker.push(payload)
+
+      Timeout.timeout(InfluxDB::Worker::SLEEP_INTERVAL) do
+        queue.pop()
+      end
+    end
+
+  end
+
+
+end


### PR DESCRIPTION
the way the threads work out currently is that 3 threads will spin up every 5 seconds and send 1000 points each, draining the queue.  This puts contention on the queue (thundering herd) and is probably less than ideal for sites that are hitting that 1000 max a lot.

randomizing the thread wake up should give a fairly even distribution of queue drains.

This also adds an integration spec for the queue.
