### PR TITLE
change logger -> logging and add the ability to swap loggers

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -15,7 +15,7 @@ module InfluxDB
 
     attr_accessor :queue, :worker
 
-    include InfluxDB::Logger
+    include InfluxDB::Logging
 
     # Initializes a new InfluxDB client
     #

--- a/lib/influxdb/logger.rb
+++ b/lib/influxdb/logger.rb
@@ -1,10 +1,20 @@
+require 'logger'
+
 module InfluxDB
-  module Logger
+  module Logging
     PREFIX = "[InfluxDB] "
+
+    def self.logger=(new_logger)
+      @logger = new_logger
+    end
+
+    def self.logger
+      @logger ||= ::Logger.new(STDERR).tap {|logger| logger.level = Logger::INFO}
+    end
 
     private
     def log(level, message)
-      STDERR.puts(PREFIX + "(#{level}) #{message}") unless level == :debug
+      InfluxDB::Logging.logger.send(level.to_sym, PREFIX + message)
     end
   end
 end

--- a/lib/influxdb/worker.rb
+++ b/lib/influxdb/worker.rb
@@ -7,7 +7,7 @@ module InfluxDB
     attr_reader :client
     attr_accessor :queue
 
-    include InfluxDB::Logger
+    include InfluxDB::Logging
 
     MAX_POST_POINTS = 1000
     NUM_WORKER_THREADS = 3


### PR DESCRIPTION
this might be controversial because changes are then necessary in the influxdb-rails gem, but I think it makes that gem and this gem cleaner.  This provides an interface to easily swap out the logger with any ruby compatible logger without having to monkey patch the InfluxDB::Logger class.
