### PR TITLE
don't retry forever when we're trying to terminate the process

### DIFF
--- a/lib/influxdb/worker.rb
+++ b/lib/influxdb/worker.rb
@@ -43,7 +43,7 @@ module InfluxDB
             check_background_queue(thread_num) until @queue.empty?
           end
 
-          while true
+          while !client.stopped?
             self.check_background_queue(thread_num)
             sleep rand(SLEEP_INTERVAL)
           end

--- a/spec/influxdb/worker_spec.rb
+++ b/spec/influxdb/worker_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require 'timeout'
 
 describe InfluxDB::Worker do
-  let(:fake_client) { double() }
+  let(:fake_client) { double(stopped?: false) }
   let(:worker) { InfluxDB::Worker.new(fake_client) }
 
   describe "#push" do


### PR DESCRIPTION
This I think is a compromise for my issue of retrying forever blocking a shutdown... now we just handle an at_exit and stop the client.
