### PR TITLE
remove username and password arg from delete_shard

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -141,9 +141,9 @@ module InfluxDB
       get full_url("/cluster/shards")
     end
 
-    def delete_shard(shard_id, server_ids, username, password)
+    def delete_shard(shard_id, server_ids)
       data = JSON.generate({"serverIds" => server_ids})
-      delete full_url("/cluster/shards/#{shard_id}", :u => username, :p => password), data
+      delete full_url("/cluster/shards/#{shard_id}"), data
     end
 
     def write_point(name, data, async=@async, time_precision=@time_precision)

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -261,7 +261,7 @@ describe InfluxDB::Client do
         :query => {:u => "username", :p => "password"}
       )
 
-      @influxdb.delete_shard(shard_id, [1, 2], "username", "password").should be_a(Net::HTTPOK)
+      @influxdb.delete_shard(shard_id, [1, 2]).should be_a(Net::HTTPOK)
     end
   end
 


### PR DESCRIPTION
These parmeters are not doing anything, the username and password parameters are explicitly set in `full_url` from their instance variables overwritting whatever was specified as function arguments
