### PR TITLE
added support for version

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -6,6 +6,11 @@ module InfluxDB
         get "/ping"
       end
 
+      def version
+        resp = get "/ping"
+        resp.header['x-influxdb-version']
+      end
+
       # rubocop:disable Metrics/MethodLength
       def query(query, opts = {})
         denormalize = opts.fetch(:denormalize, config.denormalize)

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -63,4 +63,13 @@ describe InfluxDB::Client do
       expect(subject.ping).to be_a(Net::HTTPNoContent)
     end
   end
+
+  describe "GET #version" do
+    it "returns 1.1.1" do
+      stub_request(:get, "http://influxdb.test:9999/ping").to_return(
+        { :status => 204, :headers => {'x-influxdb-version' => '1.1.1'} })
+
+      expect(subject.version).to eq('1.1.1')
+    end
+  end
 end


### PR DESCRIPTION
Sometimes you want to know what influxdb version is the server running, to understand what features are supported, etc.