### PR TITLE
Escaping Equals Signs

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -37,6 +37,7 @@ module InfluxDB
     def escape_value(value, quote_escape)
       val = value.
         gsub(/\s/, '\ ').
+        gsub('=', '\=').
         gsub(',', '\,').
         gsub('"', '\"')
       val = %("#{val}") if quote_escape
@@ -44,7 +45,7 @@ module InfluxDB
     end
 
     def escape_key(key)
-      key.to_s.gsub(/\s/, '\ ').gsub(',', '\,')
+      key.to_s.gsub(/\s/, '\ ').gsub('=', '\=').gsub(',', '\,')
     end
   end
 end

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -41,6 +41,21 @@ describe InfluxDB::PointValue do
     end
   end
 
+  describe "equal escaping" do
+    it 'should escape equals signs of a field key' do
+      point = InfluxDB::PointValue.new(series: "responses",
+                                       values: { 'a=b' => 5 })
+      expect(point.values).to eq("a\\=b=5")
+    end
+
+    it 'should escape equals signs of a tag key and a tag value' do
+      point = InfluxDB::PointValue.new(series: "responses",
+                                       values: { value: '442221834240i' },
+                                       tags: { 'a=b' => "x=y"})
+      expect(point.tags).to eq("a\\=b=x\\=y")
+    end
+  end
+
   describe 'dump' do
     context "with all possible data passed" do
       let(:expected_value) do


### PR DESCRIPTION
I appended escaping equals signs to escape_value and escape_key functions.
I wonder that equals signs are not escaped in a tag key, a tag value or a field value,
referring to "Escaping Characters" in https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html.

In fact, when I attempt to write a record containing equals signs on InfluxDB through "fluent-plugin-influxdb",
I received the following error.

```
2015-11-11 16:52:58 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2015-11-11 16:52:58 +0900 error_class="InfluxDB::Error" error="unable to parse 'test_escaping_characters,invalid==\\ \\, value=\"spam\" 1447228372': missing tag value\n" plugin_id="object:16d78f0"
```

Please point it out, if I'm mistaken.
Regards,