### PR TITLE
Fix escaping issue

### DIFF
--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -1,43 +1,20 @@
 require "spec_helper"
 
 describe InfluxDB::PointValue do
-  describe "whitespace escaping" do
-    it 'should escape series name' do
-      point = InfluxDB::PointValue.new(series: "Some Long String", values: { value: 5 })
-      expect(point.series).to eq("Some\\ Long\\ String")
+  describe "escaping" do
+    let(:data) do
+      {
+        series: '1= ,"\\1',
+        tags: {'2= ,"\\2' => '3= ,"\\3'},
+        values: {'4= ,"\\4' => '5= ,"\\5'},
+      }
     end
 
-    it 'should escape keys of passed value keys' do
-      point = InfluxDB::PointValue.new(series: "responses",
-                                       values: { 'some string key' => 5 })
-      expect(point.values.split("=").first).to eq("some\\ string\\ key")
-    end
-
-    it 'should escape passed values' do
-      point = InfluxDB::PointValue.new(series: "responses",
-                                       values: { response_time: 0.34343 },
-                                       tags: { city: "Twin Peaks" })
-      expect(point.tags.split("=").last).to eq("Twin\\ Peaks")
-    end
-  end
-
-  describe "comma escaping" do
-    it 'should escape series name' do
-      point = InfluxDB::PointValue.new(series: "Some Long String,", values: { value: 5 })
-      expect(point.series).to eq("Some\\ Long\\ String\\,")
-    end
-
-    it 'should escape keys of passed value keys' do
-      point = InfluxDB::PointValue.new(series: "responses",
-                                       values: { 'some string key,' => 5 })
-      expect(point.values.split("=").first).to eq("some\\ string\\ key\\,")
-    end
-
-    it 'should escape passed values' do
-      point = InfluxDB::PointValue.new(series: "responses",
-                                       values: { response_time: 0.34343 },
-                                       tags: { city: "Twin Peaks," })
-      expect(point.tags.split("=").last).to eq("Twin\\ Peaks\\,")
+    it 'should escape correctly' do
+      point = InfluxDB::PointValue.new(data)
+      expected = %(1=\\ \\,"\\1,2\\=\\ \\,"\\2=3\\=\\ \\,"\\3 )+
+                 %(4\\=\\ \\,\\"\\4="5= ,\\"\\5")
+      expect(point.dump).to eq(expected)
     end
   end
 


### PR DESCRIPTION
This PR fixes both #115 and  #119.

I'm sorry this is a big patch, but I found escaping rule of the [Line Protocol](https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html) is very comprecated. Here is a summary of which character needs escaping. 

|character|measurement name|tag key,tag value|field key|field value|
|---------|-----------------|-----------------|---------|-----------|
|Equal sign(`=`)  | no|yes|yes|no|
|Whitespace(` `)  |yes|yes|yes|no|
|Comma(`,`)       |yes|yes|yes|no|
|Double quote(`"`)| no| no|yes|yes|
|Backslash        | no| no|no|no|

The following is a test that influxdb gem can correctly escape these characters. I confirmed this test works well with InfluxDB 0.9.5.1.

```rb
require 'influxdb'

# Generate a string with special characters
def S(i)
  "#{i}= ,\"\\#{i}"
end

# Connect to influxdb
influxdb = InfluxDB::Client.new(host: "10.0.0.4", database: "junk")

# Write a point
n = Time.now.to_i
p influxdb.write_point(S(1), values: {S(2) => S(3), "n" => n}, tags: {S(4) => S(5)})

# Query the point
res = influxdb.query(%(SELECT * FROM "1= ,\\"\\\\1" WHERE n=#{n}), denormalize: false)
p res

# Check if stored as expected
raise if res[0]["name"] != S(1)
raise if res[0]["columns"][1] != S(2)
raise if res[0]["values"][0][1] != S(3)
raise if res[0]["columns"][2] != S(4)
raise if res[0]["values"][0][2] != S(5)
puts "ok"
```

