### PR TITLE
Ensure to balance requests in round robin

### DIFF
--- a/lib/influxdb/client/http.rb
+++ b/lib/influxdb/client/http.rb
@@ -37,12 +37,11 @@ module InfluxDB
     private
 
     def connect_with_retry(&block)
-      hosts = config.hosts.dup
+      host = config.next_host
       delay = config.initial_delay
       retry_count = 0
 
       begin
-        hosts.push(host = hosts.shift)
         http = Net::HTTP.new(host, config.port)
         http.open_timeout = config.open_timeout
         http.read_timeout = config.read_timeout

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -28,6 +28,7 @@ module InfluxDB
     def initialize(opts = {})
       @database = opts[:database]
       @hosts = Array(opts[:hosts] || opts[:host] || ["localhost"])
+      @hosts_enumerator = @hosts.cycle
       @port = opts.fetch(:port, 8086)
       @prefix = opts.fetch(:prefix, '')
       @username = opts.fetch(:username, "root")
@@ -63,6 +64,10 @@ module InfluxDB
 
     def async?
       !!async
+    end
+
+    def next_host
+      @hosts_enumerator.next
     end
   end
 end


### PR DESCRIPTION
This PR fixes built-in load balancing to balance requests to all hosts equally.