### PR TITLE
writing correct integer value according to Line protocol

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -30,6 +30,7 @@ module InfluxDB
       data.map do |k, v|
         key = escape_key(k)
         val = v.is_a?(String) ? escape_value(v, quote_escape) : v
+        val = val.is_a?(Integer) ? "#{val}i" : v
         "#{key}=#{val}"
       end
     end


### PR DESCRIPTION
When using influxdb_0.10.3-1_amd64.deb with influxdb-ruby 0.2.3, this change fixes type errors like:

{"error":"write failed: field type conflict: input field \"the field\" on measurement \"the series\" is type float64, already exists as type integer"}

