### PR TITLE
Return all result series when querying multiple selects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
   - ruby-head
   - jruby-20mode
   - jruby-21mode

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 influxdb-ruby
 =============
 
-[![Build Status](https://travis-ci.org/influxdb/influxdb-ruby.png?branch=master)](https://travis-ci.org/influxdb/influxdb-ruby)
+[![Build Status](https://travis-ci.org/influxdata/influxdb-ruby.svg?branch=master)](https://travis-ci.org/influxdb/influxdb-ruby)
 
-The official ruby client library for [InfluxDB](https://influxdb.com/). Maintained by [@toddboom](https://github.com/toddboom).
+The official ruby client library for [InfluxDB](https://influxdata.com/time-series-platform/influxdb/). Maintained by [@toddboom](https://github.com/toddboom).
 
 > **Support for InfluxDB v0.8.x is now deprecated**. The final version of this library that will support the older InfluxDB interface is `v0.1.9`, which is available as a gem and tagged on this repository. If you're reading this message, then you should only expect support for InfluxDB v0.9.1 and higher.
 
@@ -477,7 +477,7 @@ Testing
 -------
 
 ```
-git clone git@github.com:influxdb/influxdb-ruby.git
+git clone git@github.com:influxdata/influxdb-ruby.git
 cd influxdb-ruby
 bundle
 bundle exec rake

--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -78,9 +78,9 @@ module InfluxDB
       end
 
       def fetch_series(response)
-        response.fetch('results', [])
-          .fetch(0, {})
-          .fetch('series', [])
+        response.fetch('results', []).flat_map{|result|
+          result.fetch('series', [])
+        }
       end
 
       def generate_payload(data)


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

---

It is possible to pass this query to InfluxDB::Client#query:

```sql
SELECT * FROM foo; SELECT * FROM bar
```

InfluxDB actually delivers multiple result series, but the Rubygem discards all but the first series. This commit fixes this behaviour and returns/yields all result series.

Additionally fixes some links in the Readme and instructs Travis to test against Ruby 2.3.