### PR TITLE
add config option for no auth

### DIFF
--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -3,7 +3,7 @@ require 'thread'
 module InfluxDB
   # InfluxDB client configuration
   class Config
-    AUTH_METHODS = ["params".freeze, "basic_auth".freeze].freeze
+    AUTH_METHODS = ["params".freeze, "basic_auth".freeze, "none".freeze].freeze
 
     attr_accessor :port,
                   :username,

--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -111,7 +111,7 @@ module InfluxDB
       end
 
       def full_url(path, params = {})
-        unless basic_auth?
+        if config.auth_method == 'params'
           params[:u] = config.username
           params[:p] = config.password
         end

--- a/spec/influxdb/cases/query_cluster_spec.rb
+++ b/spec/influxdb/cases/query_cluster_spec.rb
@@ -22,14 +22,30 @@ describe InfluxDB::Client do
     let(:pass) { 'passpass' }
     let(:query) { "CREATE USER #{user} WITH PASSWORD '#{pass}' WITH ALL PRIVILEGES" }
 
-    before do
-      stub_request(:get, "http://influxdb.test:9999/query").with(
-        query: { u: "username", p: "password", q: query }
-      )
+    context 'with existing admin user' do
+      before do
+        stub_request(:get, "http://influxdb.test:9999/query").with(
+          query: { u: "username", p: "password", q: query }
+        )
+      end
+
+      it "should GET to create a new cluster admin" do
+        expect(subject.create_cluster_admin(user, pass)).to be_a(Net::HTTPOK)
+      end
     end
 
-    it "should GET to create a new cluster admin" do
-      expect(subject.create_cluster_admin(user, pass)).to be_a(Net::HTTPOK)
+    context 'with no admin user' do
+      let(:args) { { auth_method: 'none' } }
+
+      before do
+        stub_request(:get, "http://influxdb.test:9999/query").with(
+          query: { q: query }
+        )
+      end
+
+      it "should GET to create a new cluster admin" do
+        expect(subject.create_cluster_admin(user, pass)).to be_a(Net::HTTPOK)
+      end
     end
   end
 


### PR DESCRIPTION
When you have an influxdb with auth configured but no admin user you can't pass `u` and `p` as params. This change adds the option to use `none` for auth method which will strip the username and password from the request.