### PR TITLE
Fix create_continuous_query method for Ruby 1.9 compatibility

### DIFF
--- a/lib/influxdb/query/continuous_query.rb
+++ b/lib/influxdb/query/continuous_query.rb
@@ -10,13 +10,13 @@ module InfluxDB
           .map { |v| { 'name' => v.first, 'query' => v.last } }
       end
 
-      def create_continuous_query(name, database, query, resample_every: nil, resample_for: nil)
+      def create_continuous_query(name, database, query, options = {})
         clause = ["CREATE CONTINUOUS QUERY", name, "ON", database]
 
-        if resample_every || resample_for
+        if options[:resample_every] || options[:resample_for]
           clause << "RESAMPLE"
-          clause << "EVERY #{resample_every}" if resample_every
-          clause << "FOR #{resample_for}"     if resample_for
+          clause << "EVERY #{options[:resample_every]}" if options[:resample_every]
+          clause << "FOR #{options[:resample_for]}"     if options[:resample_for]
         end
 
         clause = clause.join(" ") << " BEGIN\n" << query << "\nEND"


### PR DESCRIPTION
@dmke please look at this, this is causing an error when requiring the gem.

```
/Users/sebastiancoetzee/.rvm/gems/ruby-1.9.3-p545@insight-app/gems/activesupport-3.2.22.2/lib/active_support/dependencies.rb:251:in `require': /Users/sebastiancoetzee/.rvm/gems/ruby-1.9.3-p545@insight-app/gems/influxdb-0.3.3/lib/influxdb/query/continuous_query.rb:13: syntax error, unexpected tLABEL (SyntaxError)
...atabase, query, resample_every: nil, resample_for: nil)
...                               ^
/Users/sebastiancoetzee/.rvm/gems/ruby-1.9.3-p545@insight-app/gems/influxdb-0.3.3/lib/influxdb/query/continuous_query.rb:13: Can't assign to nil
...se, query, resample_every: nil, resample_for: nil)
...                               ^
/Users/sebastiancoetzee/.rvm/gems/ruby-1.9.3-p545@insight-app/gems/influxdb-0.3.3/lib/influxdb/query/continuous_query.rb:31: syntax error, unexpected keyword_end, expecting $end
```