### PR TITLE
Make ping and version calls consistent with client connection configuration.

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -3,12 +3,12 @@ module InfluxDB
     # rubocop:disable Metrics/AbcSize
     module Core
       def ping
-        get "/ping".freeze
+        url = URI::Generic.build(path: File.join(config.prefix, '/ping')).to_s
+        get url
       end
 
       def version
-        resp = get "/ping".freeze
-        resp.header['x-influxdb-version']
+        ping.header['x-influxdb-version']
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -62,6 +62,17 @@ describe InfluxDB::Client do
 
       expect(subject.ping).to be_a(Net::HTTPNoContent)
     end
+
+    context "with prefix" do
+      let(:args) { { prefix: '/dev' } }
+
+      it "returns OK with prefix" do
+        stub_request(:get, "http://influxdb.test:9999/dev/ping")
+          .to_return(status: 204)
+
+        expect(subject.ping).to be_a(Net::HTTPNoContent)
+      end
+    end
   end
 
   describe "GET #version" do
@@ -70,6 +81,17 @@ describe InfluxDB::Client do
         .to_return(status: 204, headers: { 'x-influxdb-version' => '1.1.1' })
 
       expect(subject.version).to eq('1.1.1')
+    end
+
+    context "with prefix" do
+      let(:args) { { prefix: '/dev' } }
+
+      it "returns 1.1.1 with prefix" do
+        stub_request(:get, "http://influxdb.test:9999/dev/ping")
+            .to_return(status: 204, headers: { 'x-influxdb-version' => '1.1.1' })
+
+        expect(subject.version).to eq('1.1.1')
+      end
     end
   end
 

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -88,7 +88,7 @@ describe InfluxDB::Client do
 
       it "returns 1.1.1 with prefix" do
         stub_request(:get, "http://influxdb.test:9999/dev/ping")
-            .to_return(status: 204, headers: { 'x-influxdb-version' => '1.1.1' })
+          .to_return(status: 204, headers: { 'x-influxdb-version' => '1.1.1' })
 
         expect(subject.version).to eq('1.1.1')
       end


### PR DESCRIPTION
Hello, I found that methods `ping` and `version` do not work correctly with some connection configuration (that uses prefix for client `initialize` method in my case). This PR fixes the issue.
