### PR TITLE
Handle gsub() if invalid byte sequence in UTF-8

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -31,7 +31,9 @@ module InfluxDB
 
     def escape(s, type)
       ESCAPES[type].each do |ch|
-        s = s.gsub(ch) { "\\#{ch}" }
+        s = s
+            .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+            .gsub(ch) { "\\#{ch}" }
       end
       s
     end


### PR DESCRIPTION
Handle gsub() if invalid byte sequence in UTF-8.

```
2016-10-12 13:01:05 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2016-10-12 13:18:47 +0000 error_class="ArgumentError" error="invalid byte sequence in UTF-8" plugin_id="object:3f8c746c12a0"
  2016-10-12 13:01:05 +0000 [warn]: suppressed same stacktrace
2016-10-12 13:09:06 +0000 [info]: shutting down fluentd
```

PoC:
```
2.1.3 :001 > "test \255".encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').split(' ')
 => ["test"]
2.1.3 :002 > "test \255".split(' ')
ArgumentError: invalid byte sequence in UTF-8
	from (irb):2:in `split'
	from (irb):2
	from /Users/donatas/.rvm/rubies/ruby-2.1.3/bin/irb:11:in `<main>'
```

@dmke 