### PR TITLE
Allow user to pass the database at the time of writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,31 @@ data = {
 influxdb.write_point(name, data, precision, retention)
 ```
 
+Write data while choosing the database:
+
+``` ruby
+require 'influxdb'
+
+username  = 'foo'
+password  = 'bar'
+database  = 'site_development'
+name      = 'foobar'
+precision = 's'
+retention = '1h.cpu'
+
+influxdb = InfluxDB::Client.new
+  username: username,
+  password: password
+
+data = {
+  values:    { value: 0 },
+  tags:      { foo: 'bar', bar: 'baz' }
+  timestamp: Time.now.to_i
+}
+
+influxdb.write_point(name, data, precision, retention, database)
+```
+
 Write multiple points in a batch (performance boost):
 
 ``` ruby

--- a/README.md
+++ b/README.md
@@ -346,9 +346,10 @@ name      = 'foobar'
 precision = 's'
 retention = '1h.cpu'
 
-influxdb = InfluxDB::Client.new
+influxdb = InfluxDB::Client.new {
   username: username,
   password: password
+}
 
 data = {
   values:    { value: 0 },

--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -51,21 +51,24 @@ module InfluxDB
       #     values: {value: 0.9999},
       #   }
       # ])
-      def write_points(data, precision = nil, retention_policy = nil)
+      def write_points(data, precision = nil, retention_policy = nil, database = nil)
         data = data.is_a?(Array) ? data : [data]
         payload = generate_payload(data)
-        writer.write(payload, precision, retention_policy)
+        writer.write(payload, precision, retention_policy, database)
       end
 
       # Example:
       # write_point('cpu', tags: {region: 'us'}, values: {internal: 60})
-      def write_point(series, data, precision = nil, retention_policy = nil)
-        write_points(data.merge(series: series), precision, retention_policy)
+      def write_point(series, data, precision = nil, retention_policy = nil, database = nil)
+        write_points(data.merge(series: series), precision, retention_policy, database)
       end
 
-      def write(data, precision, retention_policy = nil)
-        precision ||= config.time_precision
-        params      = { db: config.database, precision: precision }
+      def write(data, precision, retention_policy = nil, database = nil)
+        params = {
+          db: database || config.database,
+          precision: precision || config.time_precision
+        }
+
         params[:rp] = retention_policy if retention_policy
         url = full_url("/write", params)
         post(url, data)

--- a/lib/influxdb/writer/async.rb
+++ b/lib/influxdb/writer/async.rb
@@ -12,7 +12,7 @@ module InfluxDB
         @config = config
       end
 
-      def write(data, _precision = nil, _retention_policy = nil)
+      def write(data, _precision = nil, _retention_policy = nil, _database = nil)
         data = data.is_a?(Array) ? data : [data]
         data.map { |p| worker.push(p) }
       end

--- a/lib/influxdb/writer/udp.rb
+++ b/lib/influxdb/writer/udp.rb
@@ -13,7 +13,7 @@ module InfluxDB
         socket.connect(host, port)
       end
 
-      def write(payload, _precision = nil, _retention_policy = nil)
+      def write(payload, _precision = nil, _retention_policy = nil, _database = nil)
         socket.send(payload, 0)
       end
     end


### PR DESCRIPTION
This allows the user to create & use one client in an application that handles many databases.
It is important that it lifts this constraint without producing any side-effects
regarding the original usage.