### PR TITLE
Rescue UDP errors

### DIFF
--- a/lib/influxdb/writer/udp.rb
+++ b/lib/influxdb/writer/udp.rb
@@ -14,7 +14,11 @@ module InfluxDB
       end
 
       def write(payload, _precision = nil, _retention_policy = nil, _database = nil)
-        socket.send(payload, 0)
+        begin
+          socket.send(payload, 0)
+        rescue => e
+          puts "Cannot write data: #{e.inspect}"
+        end
       end
     end
   end


### PR DESCRIPTION
As specified in the [RFC 1122](https://tools.ietf.org/html/rfc1122#page-79) UDP can return (asynchronous) errors especially if a previous packet was received.
An easy way to reproduce is:

- Server UDP UP
- Send a packet - OK
- Server UDP DOWN
- Send a packet - OK
- Send a packet - KO and raises an `ECONNRESET` error.

This fixes this, LMK what you think.

--- 
Also (out of scope) would you take a PR to allow to change the `writer`? So we don't need to point our Gemfile to a fork and just have our writer in our codebase.