### PR TITLE
Allow configuration by an URL

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -48,6 +48,8 @@ module InfluxDB
     # +:verify_ssl+:: verify ssl server certificate?
     # +:ssl_ca_cert+:: ssl CA certificate, chainfile or CA path.
     #                  The system CA path is automatically included
+    # +:url+:: configure everything with a single URL, eg: tls://user:pass@host/db
+    #          scheme "tls" and "ssl" enables ssl, "udp" makes it talk udp, everything else plain tcp
     def initialize(*args)
       opts = args.last.is_a?(Hash) ? args.last : {}
       opts[:database] = args.first if args.first.is_a? String

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'uri'
 
 module InfluxDB
   # InfluxDB client configuration
@@ -28,6 +29,7 @@ module InfluxDB
     attr_reader :async, :udp
 
     def initialize(opts = {})
+      merge_url(opts)
       extract_http_options!(opts)
       extract_ssl_options!(opts)
       extract_database_options!(opts)
@@ -117,6 +119,18 @@ module InfluxDB
 
     def extract_query_options!(opts)
       @chunk_size = opts.fetch :chunk_size, nil
+    end
+
+    def merge_url(opts)
+      return unless opts[:url]
+      u = URI.parse opts[:url]
+      opts[:host] = u.host
+      opts[:port] = u.port if u.port
+      opts[:username] = u.user if u.user
+      opts[:password] = u.password if u.password
+      opts[:database] = u.path[1..-1] if u.path.length > 1
+      opts[:use_ssl] = true if %w(ssl tls).include? u.scheme
+      opts[:udp] = true if u.scheme == "udp"
     end
   end
 end


### PR DESCRIPTION
Allows you to configure the Influx client with an URL, eg: 
```
InfluxDB::Client.new url: "tls://user:pass@myhost/mydb"
```