### PR TITLE
Support for `SHARD DURATION` in retention policy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ Metrics/ModuleLength:
   CountComments: false  # count full line comments?
   Max: 120
 
+Metrics/ParameterLists:
+  Max: 6
+
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ For the full commit log, [see here](https://github.com/influxdata/influxdb-ruby/
 
 ## Unreleased changes
 
-- None yet.
+- Add support for `SHARD DURATION` in retention policy (@ljagiello)
 
 ## v0.5.0, released 2017-10-21
 

--- a/lib/influxdb/query/retention_policy.rb
+++ b/lib/influxdb/query/retention_policy.rb
@@ -1,14 +1,17 @@
 module InfluxDB
   module Query
     module RetentionPolicy # :nodoc:
-      def create_retention_policy(name, database, duration, replication, options = {})
-        defaults = { default: false, shard_duration: nil }
-        options = defaults.merge(options)
+      def create_retention_policy(name,
+                                  database,
+                                  duration,
+                                  replication,
+                                  default = false,
+                                  shard_duration: nil)
         execute(
           "CREATE RETENTION POLICY \"#{name}\" ON #{database} " \
           "DURATION #{duration} REPLICATION #{replication}" \
-          "#{options[:shard_duration] ? " SHARD DURATION #{options[:shard_duration]}" : ''}" \
-          "#{options[:default] ? ' DEFAULT' : ''}"
+          "#{shard_duration ? " SHARD DURATION #{shard_duration}" : ''}" \
+          "#{default ? ' DEFAULT' : ''}"
         )
       end
 
@@ -27,14 +30,17 @@ module InfluxDB
         execute("DROP RETENTION POLICY \"#{name}\" ON #{database}")
       end
 
-      def alter_retention_policy(name, database, duration, replication, options = {})
-        defaults = { default: false, shard_duration: nil }
-        options = defaults.merge(options)
+      def alter_retention_policy(name,
+                                 database,
+                                 duration,
+                                 replication,
+                                 default = false,
+                                 shard_duration: nil)
         execute(
           "ALTER RETENTION POLICY \"#{name}\" ON #{database} " \
           "DURATION #{duration} REPLICATION #{replication}" \
-          "#{options[:shard_duration] ? " SHARD DURATION #{options[:shard_duration]}" : ''}" \
-          "#{options[:default] ? ' DEFAULT' : ''}"
+          "#{shard_duration ? " SHARD DURATION #{shard_duration}" : ''}" \
+          "#{default ? ' DEFAULT' : ''}"
         )
       end
     end

--- a/lib/influxdb/query/retention_policy.rb
+++ b/lib/influxdb/query/retention_policy.rb
@@ -1,10 +1,14 @@
 module InfluxDB
   module Query
     module RetentionPolicy # :nodoc:
-      def create_retention_policy(name, database, duration, replication, default = false)
+      def create_retention_policy(name, database, duration, replication, options = {})
+        defaults = { default: false, shard_duration: nil }
+        options = defaults.merge(options)
         execute(
           "CREATE RETENTION POLICY \"#{name}\" ON #{database} " \
-          "DURATION #{duration} REPLICATION #{replication}#{default ? ' DEFAULT' : ''}"
+          "DURATION #{duration} REPLICATION #{replication}" \
+          "#{options[:shard_duration] ? " SHARD DURATION #{options[:shard_duration]}" : ''}" \
+          "#{options[:default] ? ' DEFAULT' : ''}"
         )
       end
 
@@ -23,10 +27,14 @@ module InfluxDB
         execute("DROP RETENTION POLICY \"#{name}\" ON #{database}")
       end
 
-      def alter_retention_policy(name, database, duration, replication, default = false)
+      def alter_retention_policy(name, database, duration, replication, options = {})
+        defaults = { default: false, shard_duration: nil }
+        options = defaults.merge(options)
         execute(
           "ALTER RETENTION POLICY \"#{name}\" ON #{database} " \
-          "DURATION #{duration} REPLICATION #{replication}#{default ? ' DEFAULT' : ''}"
+          "DURATION #{duration} REPLICATION #{replication}" \
+          "#{options[:shard_duration] ? " SHARD DURATION #{options[:shard_duration]}" : ''}" \
+          "#{options[:default] ? ' DEFAULT' : ''}"
         )
       end
     end

--- a/spec/influxdb/cases/query_retention_policy_spec.rb
+++ b/spec/influxdb/cases/query_retention_policy_spec.rb
@@ -40,7 +40,7 @@ describe InfluxDB::Client do
       let(:query) { "CREATE RETENTION POLICY \"1h.cpu\" ON foo DURATION 1h REPLICATION 2 DEFAULT" }
 
       it "should GET to create a new database" do
-        expect(subject.create_retention_policy('1h.cpu', 'foo', '1h', 2, true)).to be_a(Net::HTTPOK)
+        expect(subject.create_retention_policy('1h.cpu', 'foo', '1h', 2, default: true)).to be_a(Net::HTTPOK)
       end
     end
 
@@ -49,6 +49,22 @@ describe InfluxDB::Client do
 
       it "should GET to create a new database" do
         expect(subject.create_retention_policy('1h.cpu', 'foo', '1h', 2)).to be_a(Net::HTTPOK)
+      end
+    end
+
+    context "default_with_shard_duration" do
+      let(:query) { "CREATE RETENTION POLICY \"1h.cpu\" ON foo DURATION 48h REPLICATION 2 SHARD DURATION 1h DEFAULT" }
+
+      it "should GET to create a new database" do
+        expect(subject.create_retention_policy('1h.cpu', 'foo', '48h', 2, default: true, shard_duration: '1h')).to be_a(Net::HTTPOK)
+      end
+    end
+
+    context "non-default_with_shard_duration" do
+      let(:query) { "CREATE RETENTION POLICY \"1h.cpu\" ON foo DURATION 48h REPLICATION 2 SHARD DURATION 1h" }
+
+      it "should GET to create a new database" do
+        expect(subject.create_retention_policy('1h.cpu', 'foo', '48h', 2, shard_duration: '1h')).to be_a(Net::HTTPOK)
       end
     end
   end
@@ -66,7 +82,7 @@ describe InfluxDB::Client do
       let(:query) { "ALTER RETENTION POLICY \"1h.cpu\" ON foo DURATION 1h REPLICATION 2 DEFAULT" }
 
       it "should GET to alter a new database" do
-        expect(subject.alter_retention_policy('1h.cpu', 'foo', '1h', 2, true)).to be_a(Net::HTTPOK)
+        expect(subject.alter_retention_policy('1h.cpu', 'foo', '1h', 2, default: true)).to be_a(Net::HTTPOK)
       end
     end
 
@@ -75,6 +91,22 @@ describe InfluxDB::Client do
 
       it "should GET to alter a new database" do
         expect(subject.alter_retention_policy('1h.cpu', 'foo', '1h', 2)).to be_a(Net::HTTPOK)
+      end
+    end
+
+    context "default_with_shard_duration" do
+      let(:query) { "ALTER RETENTION POLICY \"1h.cpu\" ON foo DURATION 48h REPLICATION 2 SHARD DURATION 1h DEFAULT" }
+
+      it "should GET to alter a new database" do
+        expect(subject.alter_retention_policy('1h.cpu', 'foo', '48h', 2, default: true, shard_duration: '1h')).to be_a(Net::HTTPOK)
+      end
+    end
+
+    context "non-default_with_shard_duration" do
+      let(:query) { "ALTER RETENTION POLICY \"1h.cpu\" ON foo DURATION 48h REPLICATION 2 SHARD DURATION 1h" }
+
+      it "should GET to alter a new database" do
+        expect(subject.alter_retention_policy('1h.cpu', 'foo', '48h', 2, shard_duration: '1h')).to be_a(Net::HTTPOK)
       end
     end
   end

--- a/spec/influxdb/cases/query_retention_policy_spec.rb
+++ b/spec/influxdb/cases/query_retention_policy_spec.rb
@@ -40,7 +40,7 @@ describe InfluxDB::Client do
       let(:query) { "CREATE RETENTION POLICY \"1h.cpu\" ON foo DURATION 1h REPLICATION 2 DEFAULT" }
 
       it "should GET to create a new database" do
-        expect(subject.create_retention_policy('1h.cpu', 'foo', '1h', 2, default: true)).to be_a(Net::HTTPOK)
+        expect(subject.create_retention_policy('1h.cpu', 'foo', '1h', 2, true)).to be_a(Net::HTTPOK)
       end
     end
 
@@ -56,7 +56,7 @@ describe InfluxDB::Client do
       let(:query) { "CREATE RETENTION POLICY \"1h.cpu\" ON foo DURATION 48h REPLICATION 2 SHARD DURATION 1h DEFAULT" }
 
       it "should GET to create a new database" do
-        expect(subject.create_retention_policy('1h.cpu', 'foo', '48h', 2, default: true, shard_duration: '1h')).to be_a(Net::HTTPOK)
+        expect(subject.create_retention_policy('1h.cpu', 'foo', '48h', 2, true, shard_duration: '1h')).to be_a(Net::HTTPOK)
       end
     end
 
@@ -82,7 +82,7 @@ describe InfluxDB::Client do
       let(:query) { "ALTER RETENTION POLICY \"1h.cpu\" ON foo DURATION 1h REPLICATION 2 DEFAULT" }
 
       it "should GET to alter a new database" do
-        expect(subject.alter_retention_policy('1h.cpu', 'foo', '1h', 2, default: true)).to be_a(Net::HTTPOK)
+        expect(subject.alter_retention_policy('1h.cpu', 'foo', '1h', 2, true)).to be_a(Net::HTTPOK)
       end
     end
 
@@ -98,7 +98,7 @@ describe InfluxDB::Client do
       let(:query) { "ALTER RETENTION POLICY \"1h.cpu\" ON foo DURATION 48h REPLICATION 2 SHARD DURATION 1h DEFAULT" }
 
       it "should GET to alter a new database" do
-        expect(subject.alter_retention_policy('1h.cpu', 'foo', '48h', 2, default: true, shard_duration: '1h')).to be_a(Net::HTTPOK)
+        expect(subject.alter_retention_policy('1h.cpu', 'foo', '48h', 2, true, shard_duration: '1h')).to be_a(Net::HTTPOK)
       end
     end
 


### PR DESCRIPTION
The `SHARD DURATION` clause determines the time range covered by a shard group.

Based on:
https://docs.influxdata.com/influxdb/v1.3/query_language/database_management/#create-retention-policies-with-create-retention-policy

Fixes #204 