### PR TITLE
README: Get time really in ms, not in ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ influxdb.write_point(name, data, time_precision)
 >
 > ```ruby
 > influxdb = InfluxDB::Client.new time_precision: "ms"
-> time = (Time.now.to_r * 10**6).to_i
+> time = (Time.now.to_r * 1000).to_i
 > influxdb.write_point("foobar", { values: { n: 42 }, timestamp: time })
 > ```
 


### PR DESCRIPTION
```
$ pry
[1] pry(main)> t = Time.now
=> 2017-11-25 19:34:56 +0400
[2] pry(main)> t.to_i
=> 1511624096
[3] pry(main)> (t.to_r * 10**6).to_i
=> 1511624096297938
[4] pry(main)> (t.to_r * 1000).to_i
=> 1511624096297
```