### PR TITLE
InfluxDB::Client#query returns results != no. of queries

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -38,6 +38,28 @@ module InfluxDB
         end
       end
 
+      def batched_query( # rubocop:disable Metrics/MethodLength
+        queries: [],
+        denormalize:  config.denormalize,
+        chunk_size:   config.chunk_size,
+        **opts
+      )
+        if queries.empty?
+          []
+        end
+
+        url = full_url("/query".freeze, query_params(queries.join(""), opts))
+        series = fetch_batched_series(get(url, parse: true, json_streaming: !chunk_size.nil?))
+
+        if block_given?
+          series.each do |s|
+            values = denormalize ? denormalize_batched_series(s) : raw_values(s)
+            yield s['name'.freeze], s['tags'.freeze], values
+          end
+        else
+          denormalize ? denormalized_batched_series_list(series) : series
+        end
+      end
       # Example:
       # write_points([
       #   {
@@ -111,6 +133,18 @@ module InfluxDB
 
       def fetch_series(response)
         response.fetch('results'.freeze, []).flat_map do |result|
+          result.fetch('series'.freeze, [])
+        end
+      end
+
+      def denormalized_batched_series_list(series_list)
+        series_list.map do |series|
+          denormalized_series_list(series)
+        end
+      end
+
+      def fetch_batched_series(response)
+        response.fetch('results'.freeze, []).map do |result|
           result.fetch('series'.freeze, [])
         end
       end

--- a/spec/influxdb/cases/query_core_spec.rb
+++ b/spec/influxdb/cases/query_core_spec.rb
@@ -33,15 +33,15 @@ describe InfluxDB::Client do
       expected_result = [{ "name" => "requests_per_minute", "tags" => nil, "values" => [] }]
       expect(subject.query(query)).to eq(expected_result)
     end
+  end
 
+  describe '#batched_query' do
     context "with multiple queries when there is no data for a query" do
-      let(:query) {
-        [
-          "SELECT value FROM requests_per_minute WHERE time > 1437019900;",
-          "SELECT value FROM requests_per_minute WHERE time > now();",
-          "SELECT value FROM requests_per_minute WHERE time > 1437019900;",
-        ].join('')
-      }
+      let(:queries) {[
+        "SELECT value FROM requests_per_minute WHERE time > 1437019900;",
+        "SELECT value FROM requests_per_minute WHERE time > now();",
+        "SELECT value FROM requests_per_minute WHERE time > 1437019900;",
+      ]}
       let(:response) do
         { "results" => [
           {"statement_id"=>0, "series"=> [{
@@ -60,28 +60,42 @@ describe InfluxDB::Client do
 
       before do
         stub_request(:get, "http://influxdb.test:9999/query")
-          .with(query: { db: "database", precision: "s", u: "username", p: "password", q: query })
+          .with(query: { db: "database", precision: "s", u: "username", p: "password", q: queries.join('') })
           .to_return(body: JSON.generate(response), status: 200)
       end
 
       it "should return responses for all statements" do
-        expect(subject.query(query).length).to eq(response['results'].length)
+        batched_result = subject.batched_query(queries: queries)
+        expect(batched_result.length).to eq(response['results'].length)
+        expect(batched_result).to eq([
+          [{
+            "name"=>"requests_per_minute",
+            "tags"=>nil,
+            "values"=> [{"time" => "2018-04-02T00:00:00Z", "value" => "204"}],
+          }],
+          [],
+          [{
+            "name"=>"requests_per_minute",
+            "tags"=>nil,
+            "values"=> [{"time" => "2018-04-02T00:00:00Z", "value" => "204"}],
+          }],
+        ])
       end
     end
 
     context "with a group by tag query" do
-      let(:query) { "SELECT value FROM requests_per_minute WHERE time > now() - 1d GROUP BY status_code;" }
+      let(:queries) { ["SELECT value FROM requests_per_minute WHERE time > now() - 1d GROUP BY status_code;"] }
       let(:response) do
         { "results" => [
           {"statement_id"=>0, "series"=> [
             {
               "name"=>"requests_per_minute",
-              "tags"=>{ "status_code": "200" },
+              "tags"=>{ "status_code" => "200" },
               "columns"=>["time", "value"],
               "values"=> [["2018-04-02T00:00:00Z", "204"]]
             }, {
               "name"=>"requests_per_minute",
-              "tags"=>{ "status_code": "500" },
+              "tags"=>{ "status_code" => "500" },
               "columns"=>["time", "value"],
               "values"=> [["2018-04-02T00:00:00Z", "204"]]
             }
@@ -91,12 +105,24 @@ describe InfluxDB::Client do
 
       before do
         stub_request(:get, "http://influxdb.test:9999/query")
-          .with(query: { db: "database", precision: "s", u: "username", p: "password", q: query })
+          .with(query: { db: "database", precision: "s", u: "username", p: "password", q: queries.join('') })
           .to_return(body: JSON.generate(response), status: 200)
       end
 
       it "should return a single result" do
-        expect(subject.query(query).length).to eq(response['results'].length)
+        batched_result = subject.batched_query(queries: queries)
+        expect(batched_result.length).to eq(response['results'].length)
+        expect(batched_result).to eq([[
+          {
+            "name"=>"requests_per_minute",
+            "tags"=>{ "status_code" => "200" },
+            "values"=> [{"time" => "2018-04-02T00:00:00Z", "value" => "204"}],
+          }, {
+            "name"=>"requests_per_minute",
+            "tags"=>{ "status_code" => "500" },
+            "values"=> [{"time" => "2018-04-02T00:00:00Z", "value" => "204"}],
+          }
+        ]])
       end
     end
   end


### PR DESCRIPTION
- InfluxDB::Client#query returns less than the number of queries it
is passed when there is no data for an intermediate query
- when called with a query that has a GROUP BY on a tag, it returns multiple
results for every distinct value of that tag

This PR currently just has failing tests to indicate the problem.

Co-authored-by: @hogaur