### PR TITLE
Adjust for 2.7-style keyword arguments

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -51,7 +51,7 @@ module InfluxDB
     # +:retry+:: number of times a failed request should be retried. Defaults to infinite.
     def initialize(database = nil, **opts)
       opts[:database] = database if database.is_a? String
-      @config = InfluxDB::Config.new(opts)
+      @config = InfluxDB::Config.new(**opts)
       @stopped = false
       @writer = find_writer
 

--- a/lib/influxdb/version.rb
+++ b/lib/influxdb/version.rb
@@ -1,3 +1,3 @@
 module InfluxDB # :nodoc:
-  VERSION = "0.7.0".freeze
+  VERSION = "0.7.1".freeze
 end


### PR DESCRIPTION
The semantics in Ruby 2.7 for calling with keyword-style parameters as "last" arguments has changed in preparation for Ruby 3.0.  This change makes a minor adjustment to remain compatible and to resolve associated rubocop warnings.

lib/influxdb/client.rb:54: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
lib/influxdb/config.rb:73: warning: The called method `initialize' is defined here