### PR TITLE
Raise error if write point values missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For the full commit log, [see here](https://github.com/influxdata/influxdb-ruby/commits/master).
 
+## unreleased
+
+- Raise a LineProtocolError if attempting to write empty values as field set is required.
+  Adds descriptive feedback to `{"error":"unable to parse '{series},{tags} ': invalid field format"}`
+
 ## v0.7.0, released 2019-01-11
 
 - Drop support for Ruby 2.2, since Bundler dropped it and we want to use

--- a/lib/influxdb/errors.rb
+++ b/lib/influxdb/errors.rb
@@ -5,6 +5,7 @@ module InfluxDB # :nodoc:
   Error               = Class.new StandardError
   AuthenticationError = Class.new Error
   ConnectionError     = Class.new Error
+  LineProtocolError   = Class.new Error
   SeriesNotFound      = Class.new Error
   JSONParserError     = Class.new Error
   QueryError          = Class.new Error

--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -46,7 +46,9 @@ module InfluxDB
     end
 
     def escape_values(values)
-      return if values.nil?
+      if values.nil? || values.empty?
+        raise InfluxDB::LineProtocolError, 'Cannot create point with empty values'
+      end
 
       values.map do |k, v|
         key = escape(k.to_s, :field_key)

--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -121,9 +121,13 @@ module InfluxDB
       end
 
       def generate_payload(data)
-        data.map do |point|
-          InfluxDB::PointValue.new(point).dump
-        end.join("\n".freeze)
+        data.map { |point| generate_point(point) }.join("\n".freeze)
+      end
+
+      def generate_point(point)
+        InfluxDB::PointValue.new(point).dump
+      rescue InfluxDB::LineProtocolError => e
+        (log :error, "Cannot write data: #{e.inspect}") && nil
       end
 
       def execute(query, db: nil, **options)

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -40,6 +40,14 @@ describe InfluxDB::PointValue do
       expected = series.join(",") + " " + fields.join(",")
       expect(point.dump).to eq(expected)
     end
+
+    context 'with empty values' do
+      let(:empty_values_data) { { series: 'test_series', values: {} } }
+
+      it 'should raise an exception' do
+        expect { InfluxDB::PointValue.new(empty_values_data) }.to raise_error(InfluxDB::LineProtocolError)
+      end
+    end
   end
 
   describe 'dump' do


### PR DESCRIPTION
Raise a LineProtocolError if attempting to write empty values as field set is required. Adds descriptive feedback to InfluxDB's response `{"error":"unable to parse '{series},{tags} ': invalid field format"}` when a value hash is provide with no keys.