### PR TITLE
Adds support for configuring HTTP Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ url = "https://influxdb.example.com:8086/database_name?open_timeout=3"
 influxdb = InfluxDB::Client.new url: url, open_timeout: 10
 ```
 
+#### Using a custom HTTP Proxy
+By default, the `Net::HTTP` proxy behavior is used (see [Net::HTTP Proxy](https://docs.ruby-lang.org/en/2.2.0/Net/HTTP.html#class-Net::HTTP-label-Proxies))
+You can optionally set a proxy address and port via the `proxy_addr` and `proxy_port` options:
+
+``` ruby
+influxdb = InfluxDB::Client.new host: "influxdb.domain.com", proxy_addr: "your.proxy.addr", proxy_port: 8080
+```
+
 ### Writing data
 
 Write some data:

--- a/lib/influxdb/client/http.rb
+++ b/lib/influxdb/client/http.rb
@@ -44,8 +44,11 @@ module InfluxDB
       delay = config.initial_delay
       retry_count = 0
 
+      proxy_addr = config.proxy_addr
+      proxy_port = config.proxy_port
+
       begin
-        http = Net::HTTP.new(host, config.port)
+        http = build_http(host, config.port)
         http.open_timeout = config.open_timeout
         http.read_timeout = config.read_timeout
 
@@ -132,6 +135,16 @@ module InfluxDB
         end
       end
       store
+    end
+
+    # Builds an http instance, taking into account any configured
+    # proxy configuration
+    def build_http(host, port)
+      if config.proxy_addr
+        Net::HTTP.new(host, port, config.proxy_addr, config.proxy_port)
+      else
+        Net::HTTP.new(host, port)
+      end
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/lib/influxdb/client/http.rb
+++ b/lib/influxdb/client/http.rb
@@ -44,9 +44,6 @@ module InfluxDB
       delay = config.initial_delay
       retry_count = 0
 
-      proxy_addr = config.proxy_addr
-      proxy_port = config.proxy_port
-
       begin
         http = build_http(host, config.port)
         http.open_timeout = config.open_timeout

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -16,6 +16,8 @@ module InfluxDB
     open_timeout:         5,
     read_timeout:         300,
     auth_method:          nil,
+    proxy_addr:           nil,
+    proxy_port:           nil,
 
     # SSL options
     use_ssl:              false,

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -211,14 +211,14 @@ describe InfluxDB::Config do
   context "given explicit proxy information" do
     let(:args) do
       [{
-         host:           "host",
-         port:           "port",
-         username:       "username",
-         password:       "password",
-         time_precision: "m",
-         proxy_addr:     "my.proxy.addr",
-         proxy_port:     8080
-       }]
+        host:           "host",
+        port:           "port",
+        username:       "username",
+        password:       "password",
+        time_precision: "m",
+        proxy_addr:     "my.proxy.addr",
+        proxy_port:     8080
+      }]
     end
 
     specify { expect(conf.proxy_addr).to eq("my.proxy.addr") }

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -20,6 +20,8 @@ describe InfluxDB::Config do
     specify { expect(conf).not_to be_udp }
     specify { expect(conf).not_to be_async }
     specify { expect(conf.epoch).to be_falsey }
+    specify { expect(conf.proxy_addr).to be_nil }
+    specify { expect(conf.proxy_port).to be_nil }
   end
 
   context "with no database specified" do
@@ -204,5 +206,22 @@ describe InfluxDB::Config do
       expect(conf.auth_method).to eq "params"
       expect(conf).not_to be_async
     end
+  end
+
+  context "given explicit proxy information" do
+    let(:args) do
+      [{
+         host:           "host",
+         port:           "port",
+         username:       "username",
+         password:       "password",
+         time_precision: "m",
+         proxy_addr:     "my.proxy.addr",
+         proxy_port:     8080
+       }]
+    end
+
+    specify { expect(conf.proxy_addr).to eq("my.proxy.addr") }
+    specify { expect(conf.proxy_port).to eq(8080) }
   end
 end


### PR DESCRIPTION
The previous behavior was to adopt the global proxy setting through
the use of the Net::HTTP module.  This change introduces two new
configuration parameters that allow for manually specifying the HTTP
Proxy to use for the InfluxDB connection.

This allows for circumstances where it may be required to use a
specific proxy only for the InfluxDB connection.