### PR TITLE
Ensure workers can send data popped off the queue at shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,10 @@ async_options = {
   # checking if there are new jobs in the queue
   sleep_interval:      5,
   # whether client will block if queue is full
-  block_on_full_queue: false
+  block_on_full_queue: false,
+  # Max time (in seconds) the main thread will wait for worker threads to stop
+  # on shutdown. Defaults to 2x sleep_interval.
+  shutdown_timeout: 10
 }
 
 influxdb = InfluxDB::Client.new database, async: async_options

--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -59,17 +59,19 @@ module InfluxDB
     end
 
     def stop!
-      if config.async?
-        # If retry was infinite (-1), set it to zero to give the main thread one
-        # last chance to flush the queue
-        config.retry = 0 if config.retry < 0
-        writer.worker.stop!
+      if @writer == self
+        @stopped = true
+      else
+        @writer.stop!
       end
-      @stopped = true
     end
 
     def stopped?
-      @stopped
+      if @writer == self
+        @stopped
+      else
+        @writer.stopped?
+      end
     end
 
     def now

--- a/lib/influxdb/writer/async.rb
+++ b/lib/influxdb/writer/async.rb
@@ -159,14 +159,14 @@ module InfluxDB
           # Signal the background threads that they should exit.
           @should_stop = true
 
-          # Flush any remaining items in the queue on the main thread
-          check_background_queue until queue.empty?
-
           # Wait for the threads to exit and then kill them
           @threads.each do |t|
             r = t.join(shutdown_timeout)
             t.kill if r.nil?
           end
+
+          # Flush any remaining items in the queue on the main thread
+          check_background_queue until queue.empty?
         end
 
         private

--- a/lib/influxdb/writer/udp.rb
+++ b/lib/influxdb/writer/udp.rb
@@ -11,6 +11,9 @@ module InfluxDB
         @port = port
       end
 
+      # No-op for UDP writers
+      def stop!; end
+
       def write(payload, _precision = nil, _retention_policy = nil, _database = nil)
         with_socket { |sock| sock.send(payload, 0) }
       end

--- a/spec/influxdb/cases/async_client_spec.rb
+++ b/spec/influxdb/cases/async_client_spec.rb
@@ -18,6 +18,10 @@ describe InfluxDB::Client do
         subject.write_point('a', values: { i: i })
       end
 
+      until worker.threads.none? {|t| t[:influxdb].nil? } do
+        sleep 1
+      end
+
       subject.stop!
 
       worker.threads.each do |t|
@@ -45,6 +49,10 @@ describe InfluxDB::Client do
         subject.write_point(series, { values: { t: 60 } }, precision, retention_policy, database)
         subject.write_point(series, { values: { t: 61 } }, precision, retention_policy, database)
 
+        until worker.threads.none? {|t| t[:influxdb].nil? } do
+          sleep 1
+        end
+
         subject.stop!
 
         expect(queue.pop).to eq ["#{series} t=60i\n#{series} t=61i", precision, retention_policy, database]
@@ -65,6 +73,10 @@ describe InfluxDB::Client do
           subject.write_point(series, { values: { t: 61 } }, precision2, retention_policy,  database)
           subject.write_point(series, { values: { t: 62 } }, precision,  retention_policy2, database)
           subject.write_point(series, { values: { t: 63 } }, precision,  retention_policy,  database2)
+
+          until worker.threads.none? {|t| t[:influxdb].nil? } do
+            sleep 1
+          end
 
           subject.stop!
 

--- a/spec/influxdb/cases/async_client_spec.rb
+++ b/spec/influxdb/cases/async_client_spec.rb
@@ -18,9 +18,7 @@ describe InfluxDB::Client do
         subject.write_point('a', values: { i: i })
       end
 
-      until worker.threads.none? {|t| t[:influxdb].nil? } do
-        sleep 1
-      end
+      sleep 1 until worker.threads.none? { |t| t[:influxdb].nil? }
 
       subject.stop!
 
@@ -38,7 +36,7 @@ describe InfluxDB::Client do
       let(:precision)        { 'test_precision' }
       let(:retention_policy) { 'test_period' }
       let(:database)         { 'test_database' }
-      let(:async_options)    { {num_worker_threads: 1, sleep_interval: 0.1} }
+      let(:async_options)    { { num_worker_threads: 1, sleep_interval: 0.1 } }
 
       it "writes aggregate payload to the client" do
         queue = Queue.new
@@ -49,9 +47,7 @@ describe InfluxDB::Client do
         subject.write_point(series, { values: { t: 60 } }, precision, retention_policy, database)
         subject.write_point(series, { values: { t: 61 } }, precision, retention_policy, database)
 
-        until worker.threads.none? {|t| t[:influxdb].nil? } do
-          sleep 1
-        end
+        sleep 1 until worker.threads.none? { |t| t[:influxdb].nil? }
 
         subject.stop!
 
@@ -74,9 +70,7 @@ describe InfluxDB::Client do
           subject.write_point(series, { values: { t: 62 } }, precision,  retention_policy2, database)
           subject.write_point(series, { values: { t: 63 } }, precision,  retention_policy,  database2)
 
-          until worker.threads.none? {|t| t[:influxdb].nil? } do
-            sleep 1
-          end
+          sleep 1 until worker.threads.none? { |t| t[:influxdb].nil? }
 
           subject.stop!
 

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe InfluxDB::Config do
-  let(:conf) do
-    InfluxDB::Client.new(*args).config
-  end
+  after { client.stop! }
+
+  let(:client) { InfluxDB::Client.new(*args) }
+  let(:conf) { client.config }
 
   let(:args) { {} }
 


### PR DESCRIPTION
Previously, any data still in the queue would be handled by the main
thread. But, any data that a worker had already popped off the queue,
but not yet sent on the wire, would be lost.

This change pushes down the logic for stopping to the writer and
worker which now tell the threads to exit and wait for them to do so.