### PR TITLE
Support persistent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ found in `lib/influxdb/config.rb` for the source of truth.
 |                 | `:open_timeout`         | 5             | socket timeout
 |                 | `:read_timeout`         | 300           | socket timeout
 |                 | `:auth_method`          | "params"      | "params", "basic_auth" or "none"
+|                 | `:persistent`           | true          | set to false to disable persistent connections
 | Retry           | `:retry`                | -1            | max. number of retry attempts (reading and writing)
 |                 | `:initial_delay`        | 0.01          | initial wait time (doubles every retry attempt)
 |                 | `:max_delay`            | 30            | max. wait time when retrying

--- a/lib/influxdb/client/http.rb
+++ b/lib/influxdb/client/http.rb
@@ -136,6 +136,8 @@ module InfluxDB
     end
 
     def get_http
+      return build_http config.next_host unless config.persistent
+
       @https ||=
         begin
           https = config.hosts.map { |host|

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -18,6 +18,7 @@ module InfluxDB
     auth_method:          nil,
     proxy_addr:           nil,
     proxy_port:           nil,
+    persistent:           true,
 
     # SSL options
     use_ssl:              false,

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -83,6 +83,12 @@ module InfluxDB
       configure_hosts! opts[:hosts] || opts[:host] || "localhost".freeze
     end
 
+    def initialize_copy(source)
+      super
+
+      configure_hosts! source.hosts
+    end
+
     def udp?
       udp != false
     end
@@ -105,7 +111,15 @@ module InfluxDB
       end
     end
 
-    private
+    def writer_config
+      writer_config = dup
+
+      writer_config.set_ivar! :async, false
+
+      writer_config
+    end
+
+    protected
 
     def set_ivar!(name, value)
       case name
@@ -117,6 +131,8 @@ module InfluxDB
 
       instance_variable_set "@#{name}", value
     end
+
+    private
 
     def normalize_retry_option(value)
       case value

--- a/lib/influxdb/logging.rb
+++ b/lib/influxdb/logging.rb
@@ -6,7 +6,6 @@ module InfluxDB
 
     class << self
       attr_writer :logger
-      attr_writer :log_level
 
       def logger
         return false if @logger == false
@@ -15,18 +14,13 @@ module InfluxDB
       end
 
       def log_level
-        @log_level || Logger::INFO
+        logger&.level || Logger::INFO
       end
 
-      def log?(level)
-        case level
-        when :debug then log_level <= Logger::DEBUG
-        when :info  then log_level <= Logger::INFO
-        when :warn  then log_level <= Logger::WARN
-        when :error then log_level <= Logger::ERROR
-        when :fatal then log_level <= Logger::FATAL
-        else true
-        end
+      def log_level=(level)
+        return unless logger
+
+        logger.level = level
       end
     end
 
@@ -34,7 +28,6 @@ module InfluxDB
 
     def log(level, message = nil, &block)
       return unless InfluxDB::Logging.logger
-      return unless InfluxDB::Logging.log?(level)
 
       if block_given?
         InfluxDB::Logging.logger.send(level.to_sym, PREFIX, &block)

--- a/spec/influxdb/cases/async_client_spec.rb
+++ b/spec/influxdb/cases/async_client_spec.rb
@@ -6,7 +6,8 @@ describe InfluxDB::Client do
   let(:client) { described_class.new(async: async_options) }
   let(:subject) { client }
   let(:stub_url) { "http://localhost:8086/write?db=&p=root&precision=s&u=root" }
-  let(:worker) { client.writer.worker }
+  let(:writer) { client.writer }
+  let(:worker) { writer.worker }
 
   specify { expect(subject.writer).to be_a(InfluxDB::Writer::Async) }
 
@@ -40,7 +41,7 @@ describe InfluxDB::Client do
 
       it "writes aggregate payload to the client" do
         queue = Queue.new
-        allow(client).to receive(:write) do |*args|
+        allow_any_instance_of(InfluxDB::Client).to receive(:write) do |_, *args|
           queue.push(args)
         end
 
@@ -61,7 +62,7 @@ describe InfluxDB::Client do
 
         it "writes separated payloads for each {precision, retention_policy, database} set" do
           queue = Queue.new
-          allow(client).to receive(:write) do |*args|
+          allow_any_instance_of(InfluxDB::Client).to receive(:write) do |_, *args|
             queue.push(args)
           end
 

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -60,6 +60,24 @@ describe InfluxDB::Client do
     end
   end
 
+  describe "#get_http" do
+    it "returns an existing connection with persistence enabled" do
+      first  = subject.send :get_http
+      second = subject.send :get_http
+
+      expect(first).to equal(second)
+    end
+
+    it "returns a new connection with persistence disabled" do
+      subject.config.persistent = false
+
+      first  = subject.send :get_http
+      second = subject.send :get_http
+
+      expect(first).to_not equal(second)
+    end
+  end
+
   describe "GET #ping" do
     it "returns OK" do
       stub_request(:get, "http://influxdb.test:9999/ping")

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -14,6 +14,7 @@ describe InfluxDB::Config do
     specify { expect(conf.port).to eq 8086 }
     specify { expect(conf.username).to eq "root" }
     specify { expect(conf.password).to eq "root" }
+    specify { expect(conf.persistent).to be_truthy }
     specify { expect(conf.use_ssl).to be_falsey }
     specify { expect(conf.time_precision).to eq "s" }
     specify { expect(conf.auth_method).to eq "params" }


### PR DESCRIPTION
The released versions of this gem do not support HTTP persistent connections.  This causes performance issues due to connection creation overhead and makes writing to the InfluxDB database fail if DNS is down when a new connection needs to be created.

Enabling persistent connections results in a ~9x speed increase allowing points to be written synchronously to a non-localhost influxDB in ~5ms instead of ~50ms for my computer.

This PR also fixes debug logging.

See commit messages for details.
