### PR TITLE
Add support for special characters in password when using url keyword

### DIFF
--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -146,11 +146,11 @@ module InfluxDB
 
     def opts_from_non_params(url)
       {}.tap do |o|
-        o[:host]     = url.host        if url.host
-        o[:port]     = url.port        if url.port
-        o[:username] = URI.decode_www_form_component(url.user)        if url.user
-        o[:password] = URI.decode_www_form_component(url.password)    if url.password
-        o[:database] = url.path[1..-1] if url.path.length > 1
+        o[:host]     = url.host                                    if url.host
+        o[:port]     = url.port                                    if url.port
+        o[:username] = URI.decode_www_form_component(url.user)     if url.user
+        o[:password] = URI.decode_www_form_component(url.password) if url.password
+        o[:database] = url.path[1..-1]                             if url.path.length > 1
         o[:use_ssl]  = url.scheme == "https".freeze
 
         o[:udp] = { host: o[:host], port: o[:port] } if url.scheme == "udp"

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -148,8 +148,8 @@ module InfluxDB
       {}.tap do |o|
         o[:host]     = url.host        if url.host
         o[:port]     = url.port        if url.port
-        o[:username] = url.user        if url.user
-        o[:password] = url.password    if url.password
+        o[:username] = URI.decode_www_form_component(url.user)        if url.user
+        o[:password] = URI.decode_www_form_component(url.password)    if url.password
         o[:database] = url.path[1..-1] if url.path.length > 1
         o[:use_ssl]  = url.scheme == "https".freeze
 

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -159,6 +159,15 @@ describe InfluxDB::Config do
       expect(conf).not_to be_async
     end
 
+    context "with encoded values" do
+      let(:url) { "https://weird%24user:weird%25pass@influx.example.com:8765/testdb" }
+
+      it "decode encoded values" do
+        expect(conf.username).to eq "weird$user"
+        expect(conf.password).to eq "weird%pass"
+      end
+    end
+
     context "UDP" do
       let(:url) { "udp://test.localhost:2345?discard_write_errors=1" }
       specify { expect(conf).to be_udp }


### PR DESCRIPTION
This pull request makes it possible to use `InfluxDB::Client.new(url: ...)` form of configuration when having more complex password using special characters which are percent encoded in URI.

I'd be very grateful for making a patch release after merging pull request :)