### PR TITLE
Try to add Ruby 3.0.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - "2.5"
   - "2.6"
   - "2.7"
+  - "3.0"
   - ruby-head
 env:
   - TEST_TASK=spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For the full commit log, [see here](https://github.com/influxdata/influxdb-ruby/
 
 ## unreleased
 
+- Support Ruby v3.0.0
 - Ensure workers can send data popped off the queue at shutdown (#239,
   @onlynone)
 


### PR DESCRIPTION
Issue: https://github.com/influxdata/influxdb-ruby/issues/245

From the warnings that pop up when running it with Ruby 2.7, I think those two methods need to be fixed: 

* lib/influxdb/client.rb:52 (initialize), f.e. from spec/influxdb/cases/querying_issue_7000_spec.rb:9, spec/influxdb/cases/query_series_spec.rb:6
* lib/influxdb/query/core.rb:88 (query_params), f.e. from lib/influxdb/query/batch.rb:86

Without knowing the codebase it's not clear to me how to fix it.