### PR TITLE
Updated usage of kwargs for Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ before_install:
   - gem update --system --no-doc
   - bin/provision.sh
 rvm:
-  - "2.3"
   - "2.4"
   - "2.5"
   - "2.6"
   - "2.7"
+  - "3.0"
   - ruby-head
 env:
   - TEST_TASK=spec
@@ -20,10 +20,10 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
     - rvm: jruby-9.2.9.0
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=nightly channel=nightlies
   include:
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: TEST_TASK=rubocop
 
     - rvm: jruby-9.1.17.0
@@ -33,23 +33,23 @@ matrix:
     - rvm: jruby-head
       env: JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -J-Xmx256M'
 
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.0.2 pkghash=88f6c30fec2c6e612e802e23b9161fdfc7c5c29f6be036f0376326445aff0037
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.1.5 pkghash=0ecb9385cc008f6e5094e6e8f8ea70522023a16d4397e401898f3973176d3b21
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.2.4 pkghash=2fac8391e04aa1bec9151e8f0d8f18df030c866af2b4963ab7d86c6ddc172182
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.3.8 pkghash=35c9cb2943bbde04aa5e94ad6d8caf5fc9b1480bdbcde7c34078de135cc4f788
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.4.3 pkghash=0477080f1d1cf8e1242dc7318280b9010c4c45cf6a415a2a5de607ae17fa0359
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.5.4 pkghash=fa6f8d3196d13ffc376d533581b534692c738181ce3427c53484c138d9e6b902
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.6.4 pkghash=dbfa13a0f9e38a8e7b19294c30144903bb681ac0aba0a3a8f4f349c37d5de5f9
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=1.7.9 pkghash=02759d70cef670d336768fd38a9cf2f046a1bf40618be78ba215e7ce75b5075f
-    - rvm: "2.7"
+    - rvm: "3.0"
       env: influx_version=nightly channel=nightlies
 addons:
   apt:

--- a/lib/influxdb/query/batch.rb
+++ b/lib/influxdb/query/batch.rb
@@ -27,7 +27,7 @@ module InfluxDB
       )
         return [] if statements.empty?
 
-        url = full_url "/query".freeze, query_params(statements.join(";"), opts)
+        url = full_url "/query".freeze, **query_params(statements.join(";"), **opts)
         series = fetch_series get(url, parse: true, json_streaming: !chunk_size.nil?)
 
         if denormalize
@@ -82,8 +82,8 @@ module InfluxDB
         denormalize_series
         denormalized_series_list
       ].each do |method_name|
-        define_method(method_name) do |*args|
-          client.send method_name, *args
+        define_method(method_name) do |*args, **kwargs|
+          client.send method_name, *args, **kwargs
         end
       end
     end

--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -26,7 +26,7 @@ module InfluxDB
       )
         query = builder.build(query, params)
 
-        url = full_url("/query".freeze, query_params(query, **opts))
+        url = full_url("/query".freeze, **query_params(query, **opts))
         series = fetch_series(get(url, parse: true, json_streaming: !chunk_size.nil?))
 
         if block_given?
@@ -79,7 +79,7 @@ module InfluxDB
         }
 
         params[:rp] = retention_policy if retention_policy
-        url = full_url("/write", params)
+        url = full_url("/write", **params)
         post(url, data)
       end
 
@@ -133,7 +133,7 @@ module InfluxDB
       def execute(query, db: nil, **options)
         params = { q: query }
         params[:db] = db if db
-        url = full_url("/query".freeze, params)
+        url = full_url("/query".freeze, **params)
         get(url, options)
       end
 
@@ -147,7 +147,7 @@ module InfluxDB
         series.select { |k, _| %w[columns values].include?(k) }
       end
 
-      def full_url(path, params = {})
+      def full_url(path, **params)
         if config.auth_method == "params".freeze
           params[:u] = config.username
           params[:p] = config.password

--- a/spec/influxdb/cases/query_cluster_spec.rb
+++ b/spec/influxdb/cases/query_cluster_spec.rb
@@ -3,7 +3,7 @@ require "json"
 
 describe InfluxDB::Client do
   let(:subject) do
-    described_class.new "database", {
+    described_class.new "database", **{
       host:           "influxdb.test",
       port:           9999,
       username:       "username",

--- a/spec/influxdb/cases/query_series_spec.rb
+++ b/spec/influxdb/cases/query_series_spec.rb
@@ -5,7 +5,7 @@ describe InfluxDB::Client do
   let(:subject) do
     described_class.new(
       "database",
-      {
+      **{
         host:           "influxdb.test",
         port:           9999,
         username:       "username",

--- a/spec/influxdb/cases/querying_issue_7000_spec.rb
+++ b/spec/influxdb/cases/querying_issue_7000_spec.rb
@@ -6,7 +6,7 @@ require "json"
 
 describe InfluxDB::Client do
   let(:subject) do
-    described_class.new "database", {
+    described_class.new "database", **{
       host:           "influxdb.test",
       port:           9999,
       username:       "username",

--- a/spec/influxdb/cases/querying_spec.rb
+++ b/spec/influxdb/cases/querying_spec.rb
@@ -3,7 +3,7 @@ require "json"
 
 describe InfluxDB::Client do
   let(:subject) do
-    described_class.new "database", {
+    described_class.new "database", **{
       host:           "influxdb.test",
       port:           9999,
       username:       "username",

--- a/spec/influxdb/cases/retry_requests_spec.rb
+++ b/spec/influxdb/cases/retry_requests_spec.rb
@@ -5,7 +5,7 @@ describe InfluxDB::Client do
   let(:client) do
     described_class.new(
       "database",
-      {
+      **{
         host:           "influxdb.test",
         port:           9999,
         username:       "username",

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -5,7 +5,7 @@ describe InfluxDB::Client do
   let(:subject) do
     described_class.new(
       "database",
-      {
+      **{
         host:           "influxdb.test",
         port:           9999,
         username:       "username",

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 describe InfluxDB::Config do
   after { client.stop! }
 
-  let(:client) { InfluxDB::Client.new(*args) }
+  let(:client) do
+    kwargs = args.last.is_a?(Hash) ? args.pop : {}
+    InfluxDB::Client.new(*args, **kwargs)
+  end
   let(:conf) { client.config }
 
-  let(:args) { {} }
+  let(:args) { [] }
 
   context "with no parameters specified" do
     specify { expect(conf.database).to be_nil }
@@ -27,13 +30,13 @@ describe InfluxDB::Config do
 
   context "with no database specified" do
     let(:args) do
-      [{
+      [
         host:           "host",
         port:           "port",
         username:       "username",
         password:       "password",
         time_precision: "m"
-      }]
+      ]
     end
 
     specify { expect(conf.database).to be_nil }
@@ -67,7 +70,7 @@ describe InfluxDB::Config do
   end
 
   context "with ssl option specified" do
-    let(:args) { [{ use_ssl: true }] }
+    let(:args) { [ use_ssl: true ] }
 
     specify { expect(conf.database).to be_nil }
     specify { expect(conf.hosts).to eq ["localhost"] }
@@ -78,7 +81,7 @@ describe InfluxDB::Config do
   end
 
   context "with multiple hosts specified" do
-    let(:args) { [{ hosts: ["1.1.1.1", "2.2.2.2"] }] }
+    let(:args) { [ hosts: ["1.1.1.1", "2.2.2.2"] ] }
 
     specify { expect(conf.database).to be_nil }
     specify { expect(conf.port).to eq 8086 }
@@ -88,7 +91,7 @@ describe InfluxDB::Config do
   end
 
   context "with auth_method basic auth specified" do
-    let(:args) { [{ auth_method: 'basic_auth' }] }
+    let(:args) { [auth_method: 'basic_auth'] }
 
     specify { expect(conf.database).to be_nil }
     specify { expect(conf.hosts).to eq ["localhost"] }
@@ -99,38 +102,38 @@ describe InfluxDB::Config do
   end
 
   context "with udp specified with params" do
-    let(:args) { [{ udp: { host: 'localhost', port: 4444 } }] }
+    let(:args) { [udp: { host: 'localhost', port: 4444 }] }
 
     specify { expect(conf).to be_udp }
   end
 
   context "with udp specified as true" do
-    let(:args) { [{ udp: true }] }
+    let(:args) { [udp: true] }
 
     specify { expect(conf).to be_udp }
   end
 
   context "with async specified with params" do
-    let(:args) { [{ async: { max_queue: 20_000 } }] }
+    let(:args) { [async: { max_queue: 20_000 }] }
 
     specify { expect(conf).to be_async }
   end
 
   context "with async specified as true" do
-    let(:args) { [{ async: true }] }
+    let(:args) { [async: true] }
 
     specify { expect(conf).to be_async }
   end
 
   context "with epoch specified as seconds" do
-    let(:args) { [{ epoch: 's' }] }
+    let(:args) { [epoch: 's'] }
 
     specify { expect(conf.epoch).to eq 's' }
   end
 
   context "given a config URL" do
     let(:url) { "https://foo:bar@influx.example.com:8765/testdb?open_timeout=42&unknown=false&denormalize=false" }
-    let(:args) { [{ url: url }] }
+    let(:args) { [url: url] }
 
     it "applies values found in URL" do
       expect(conf.database).to eq "testdb"
@@ -211,15 +214,14 @@ describe InfluxDB::Config do
 
   context "given explicit proxy information" do
     let(:args) do
-      [{
-        host:           "host",
-        port:           "port",
-        username:       "username",
-        password:       "password",
-        time_precision: "m",
-        proxy_addr:     "my.proxy.addr",
-        proxy_port:     8080
-      }]
+      [host:           "host",
+       port:           "port",
+       username:       "username",
+       password:       "password",
+       time_precision: "m",
+       proxy_addr:     "my.proxy.addr",
+       proxy_port:     8080
+      ]
     end
 
     specify { expect(conf.proxy_addr).to eq("my.proxy.addr") }


### PR DESCRIPTION
Pretty standard fixes that were warnings in Ruby 2.7. The only interesting part was in Config spec, I had to split the args array into kwargs manually.

Further reading: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes #245 