### PR TITLE
Usernames and database names have to be quoted.

### DIFF
--- a/lib/influxdb/query/cluster.rb
+++ b/lib/influxdb/query/cluster.rb
@@ -2,7 +2,7 @@ module InfluxDB
   module Query
     module Cluster # :nodoc:
       def create_cluster_admin(username, password)
-        execute("CREATE USER #{username} WITH PASSWORD '#{password}' WITH ALL PRIVILEGES")
+        execute("CREATE USER \"#{username}\" WITH PASSWORD '#{password}' WITH ALL PRIVILEGES")
       end
 
       def list_cluster_admins
@@ -10,7 +10,7 @@ module InfluxDB
       end
 
       def revoke_cluster_admin_privileges(username)
-        execute("REVOKE ALL PRIVILEGES FROM #{username}")
+        execute("REVOKE ALL PRIVILEGES FROM \"#{username}\"")
       end
     end
   end

--- a/lib/influxdb/query/continuous_query.rb
+++ b/lib/influxdb/query/continuous_query.rb
@@ -24,7 +24,7 @@ module InfluxDB
       end
 
       def delete_continuous_query(name, database)
-        execute("DROP CONTINUOUS QUERY #{name} ON #{database}")
+        execute("DROP CONTINUOUS QUERY \"#{name}\" ON \"#{database}\"")
       end
     end
   end

--- a/lib/influxdb/query/database.rb
+++ b/lib/influxdb/query/database.rb
@@ -2,11 +2,11 @@ module InfluxDB
   module Query
     module Database # :nodoc:
       def create_database(name = nil)
-        execute("CREATE DATABASE #{name || config.database}")
+        execute("CREATE DATABASE \"#{name || config.database}\"")
       end
 
       def delete_database(name = nil)
-        execute("DROP DATABASE #{name || config.database}")
+        execute("DROP DATABASE \"#{name || config.database}\"")
       end
 
       def list_databases

--- a/lib/influxdb/query/user.rb
+++ b/lib/influxdb/query/user.rb
@@ -6,36 +6,36 @@ module InfluxDB
       def create_database_user(database, username, password, options = {})
         permissions = options.fetch(:permissions, :all)
         execute(
-          "CREATE user #{username} WITH PASSWORD '#{password}'; "\
-          "GRANT #{permissions.to_s.upcase} ON #{database} TO #{username}"
+          "CREATE user \"#{username}\" WITH PASSWORD '#{password}'; "\
+          "GRANT #{permissions.to_s.upcase} ON \"#{database}\" TO \"#{username}\""
         )
       end
 
       def update_user_password(username, password)
-        execute("SET PASSWORD FOR #{username} = '#{password}'")
+        execute("SET PASSWORD FOR \"#{username}\" = '#{password}'")
       end
 
       # permission => [:all]
       def grant_user_admin_privileges(username)
-        execute("GRANT ALL PRIVILEGES TO #{username}")
+        execute("GRANT ALL PRIVILEGES TO \"#{username}\"")
       end
 
       # permission => [:read|:write|:all]
       def grant_user_privileges(username, database, permission)
-        execute("GRANT #{permission.to_s.upcase} ON #{database} TO #{username}")
+        execute("GRANT #{permission.to_s.upcase} ON \"#{database}\" TO \"#{username}\"")
       end
 
       def list_user_grants(username)
-        execute("SHOW GRANTS FOR #{username}")
+        execute("SHOW GRANTS FOR \"#{username}\"")
       end
 
       # permission => [:read|:write|:all]
       def revoke_user_privileges(username, database, permission)
-        execute("REVOKE #{permission.to_s.upcase} ON #{database} FROM #{username}")
+        execute("REVOKE #{permission.to_s.upcase} ON \"#{database}\" FROM \"#{username}\"")
       end
 
       def delete_user(username)
-        execute("DROP USER #{username}")
+        execute("DROP USER \"#{username}\"")
       end
 
       # => [{"username"=>"usr", "admin"=>true}, {"username"=>"justauser", "admin"=>false}]


### PR DESCRIPTION
It's legal for databases and users to have odd characters that require quoting. This is done in some parts of the code but not others. I think I found all the places where the quoting needs to happen but I would appreciate a look over.

## Errors

Hopefully some other poor soul won't have waste time finding this out the hard way. So here's some error dumps that search engines might key onto if your database has a `-` in it.

```
InfluxDB::Error: {"error":"error parsing query: found -, expected ; at line 1, char 20"}
```

```
Feb 02 18:11:33 host c32443048d41[3669]: /usr/local/bundle/gems/influxdb-0.3.17/lib/influxdb/client/http.rb:85:in `resolve_error': {"error":"error parsing query: found -, expected ; at line 1, char 20"} (InfluxDB::Error)
Feb 02 18:11:33 host c32443048d41[3669]:         from /usr/local/bundle/gems/influxdb-0.3.17/lib/influxdb/client/http.rb:19:in `block in get'
Feb 02 18:11:33 host c32443048d41[3669]:         from /usr/local/bundle/gems/influxdb-0.3.17/lib/influxdb/client/http.rb:53:in `connect_with_retry'
Feb 02 18:11:33 host c32443048d41[3669]:         from /usr/local/bundle/gems/influxdb-0.3.17/lib/influxdb/client/http.rb:11:in `get'
Feb 02 18:11:33 host c32443048d41[3669]:         from /usr/local/bundle/gems/influxdb-0.3.17/lib/influxdb/query/core.rb:129:in `execute'
Feb 02 18:11:33 host c32443048d41[3669]:         from /usr/local/bundle/gems/influxdb-0.3.17/lib/influxdb/query/database.rb:5:in `create_database'

