### PR TITLE
Correct Delegation with ruby2_keywords

### DIFF
--- a/lib/influxdb/query/batch.rb
+++ b/lib/influxdb/query/batch.rb
@@ -82,15 +82,10 @@ module InfluxDB
         denormalize_series
         denormalized_series_list
       ].each do |method_name|
-        if RUBY_VERSION < "2.7"
-          define_method(method_name) do |*args|
-            client.send method_name, *args
-          end
-        else
-          define_method(method_name) do |*args, **kwargs|
-            client.send method_name, *args, **kwargs
-          end
+        define_method(method_name) do |*args|
+          client.send method_name, *args
         end
+        ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
       end
     end
   end


### PR DESCRIPTION
My change in 24440f9b61e9333bcd2bdd81f24715b9f5c84dca wasn't fully correct

See https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html and https://github.com/ruby/ruby2_keywords/issues/6