### PR TITLE
Use defined? to check if the @worker variable is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For the full commit log, [see here](https://github.com/influxdata/influxdb-ruby/commits/master).
 
+## unreleased
+
+- Check if `@worker` is defined using ruby's `defined?` method
+
 ## v0.8.1, release 2021-02-17
 
 - Ensure workers can send data popped off the queue at shutdown (#239,

--- a/lib/influxdb/writer/async.rb
+++ b/lib/influxdb/writer/async.rb
@@ -28,12 +28,12 @@ module InfluxDB
 
       WORKER_MUTEX = Mutex.new
       def worker
-        return @worker if @worker
+        return @worker if defined? @worker
 
         WORKER_MUTEX.synchronize do
           # this return is necessary because the previous mutex holder
           # might have already assigned the @worker
-          return @worker if @worker
+          return @worker if defined? @worker
 
           @worker = Worker.new(client, config)
         end

--- a/lib/influxdb/writer/async.rb
+++ b/lib/influxdb/writer/async.rb
@@ -28,12 +28,12 @@ module InfluxDB
 
       WORKER_MUTEX = Mutex.new
       def worker
-        return @worker if defined? @worker
+        return @worker if @worker
 
         WORKER_MUTEX.synchronize do
           # this return is necessary because the previous mutex holder
           # might have already assigned the @worker
-          return @worker if defined? @worker
+          return @worker if @worker
 
           @worker = Worker.new(client, config)
         end


### PR DESCRIPTION
## Summary

While writing some specs for a client wrapper I noticed that there were many warnings for the worker not being defined during my rspec run.

While I could patch this in my application, I felt the community might appreciate a subtle amendment to the way we check whether or not the `@worker` variable is defined or not.

### Example

```ruby
/Users/user/.rvm/gems/ruby-2.6.6/gems/influxdb-0.8.1/lib/influxdb/writer/async.rb:31: warning: instance variable @worker not initialized
/Users/user/.rvm/gems/ruby-2.6.6/gems/influxdb-0.8.1/lib/influxdb/writer/async.rb:36: warning: instance variable @worker not initialized
```